### PR TITLE
Add ROS2 common interfaces

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -147,8 +147,6 @@ fn extractInterface(dep: *std.Build.Dependency, name: []const u8) RosidlGenerato
 var lazy_deps_needed = false;
 
 pub const ZigRos = struct {
-    pub const CompileArgs = zigros.CompileArgs;
-
     ros_libraries: RosLibraries,
     python_libraries: PythonLibraries,
     python: zigros.PythonDep,
@@ -255,18 +253,6 @@ pub const ZigRos = struct {
         self.ros_libraries.builtin_interfaces.linkC(module);
         module.addIncludePath(self.ros_libraries.rosidl_typesupport_interface);
         module.linkLibrary(self.ros_libraries.rosidl_dynamic_typesupport);
-
-        self.ros_libraries.actionlib_msgs.linkC(module);
-        self.ros_libraries.diagnostic_msgs.linkC(module);
-        self.ros_libraries.geometry_msgs.linkC(module);
-        self.ros_libraries.nav_msgs.linkC(module);
-        self.ros_libraries.sensor_msgs.linkC(module);
-        self.ros_libraries.shape_msgs.linkC(module);
-        self.ros_libraries.std_msgs.linkC(module);
-        self.ros_libraries.std_srvs.linkC(module);
-        self.ros_libraries.stereo_msgs.linkC(module);
-        self.ros_libraries.trajectory_msgs.linkC(module);
-        self.ros_libraries.visualization_msgs.linkC(module);
     }
 
     pub fn linkRclcpp(self: ZigRos, module: *Module) void {
@@ -277,18 +263,6 @@ pub const ZigRos = struct {
         self.ros_libraries.builtin_interfaces.linkCpp(module);
         self.ros_libraries.statistics_msgs.link(module);
         self.ros_libraries.rosgraph_msgs.link(module);
-
-        self.ros_libraries.actionlib_msgs.linkCpp(module);
-        self.ros_libraries.diagnostic_msgs.linkCpp(module);
-        self.ros_libraries.geometry_msgs.linkCpp(module);
-        self.ros_libraries.nav_msgs.linkCpp(module);
-        self.ros_libraries.sensor_msgs.linkCpp(module);
-        self.ros_libraries.shape_msgs.linkCpp(module);
-        self.ros_libraries.std_msgs.linkCpp(module);
-        self.ros_libraries.std_srvs.linkCpp(module);
-        self.ros_libraries.stereo_msgs.linkCpp(module);
-        self.ros_libraries.trajectory_msgs.linkCpp(module);
-        self.ros_libraries.visualization_msgs.linkCpp(module);
 
         module.addIncludePath(self.ros_libraries.tracetools);
         module.addIncludePath(self.ros_libraries.rosidl_runtime_cpp);

--- a/build.zig
+++ b/build.zig
@@ -146,9 +146,9 @@ fn extractInterface(dep: *std.Build.Dependency, name: []const u8) RosidlGenerato
 // The build/configure step sets this if its missing lazy deps which allows the ZigRos init call to return null if it's not set
 var lazy_deps_needed = false;
 
-pub const CompileArgs = zigros.CompileArgs;
-
 pub const ZigRos = struct {
+    pub const CompileArgs = zigros.CompileArgs;
+
     ros_libraries: RosLibraries,
     python_libraries: PythonLibraries,
     python: zigros.PythonDep,

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -107,6 +107,7 @@
         "build.zig.zon",
         "ament_index/build.zig",
         "libstatistics_collector/build.zig",
+        "common_interfaces/build.zig",
         "rcl/build.zig",
         "rclcpp/build.zig",
         "rcl_interfaces/build.zig",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -85,6 +85,10 @@
             .url = "https://github.com/zig-robotics/ros2-rclcpp/archive/435f377374a363889b95ce011020d80d3682c24e.tar.gz", // Jazzy
             .hash = "N-V-__8AAFLpQAA6Ilb6UvWM6QZpuiXNyegIJYyrN7cIqrw5",
         },
+        .ros2_common_interfaces = .{
+            .url = "https://github.com/ros2/common_interfaces/archive/refs/tags/5.4.2.tar.gz",
+            .hash = "N-V-__8AAJatCADp2QPDFq8wzBG--OTM2oVMdj3kk5FLvnk0",
+        },
         .cyclonedds = .{
             .url = "https://github.com/zig-robotics/cyclonedds/archive/tags/0.10.5.tar.gz",
             .hash = "cyclonedds-0.10.5-VJFfyyI6AADru0dTKFhIVjebuuArgt68TI77ARc1_qD8",

--- a/common_interfaces/README.md
+++ b/common_interfaces/README.md
@@ -14,5 +14,7 @@ This builds the common_interfaces from ROS2:
 - trajectory_msgs
 - visualization_msgs
 
-All of the above message libraries will automatically be included and linked when calling
-`zigros.linkRcl()` and `zigros.linkRclCpp()`.
+To utilize the libraries in your build, call `zigros.ros_libraries.sensor_msgs.link(your_exe.root_module)`.
+You will also need to manually specify any interface dependencies.
+Dependency management is still being sorted out.
+

--- a/common_interfaces/README.md
+++ b/common_interfaces/README.md
@@ -1,0 +1,18 @@
+# Zig package for ROS2 Common Interfaces
+
+This builds the common_interfaces from ROS2:
+
+- actionlib_msgs
+- diagnostic_msgs
+- geometry_msgs
+- nav_msgs
+- sensor_msgs
+- shape_msgs
+- std_msgs
+- std_srvs
+- stereo_msgs
+- trajectory_msgs
+- visualization_msgs
+
+All of the above message libraries will automatically be included and linked when calling
+`zigros.linkRcl()` and `zigros.linkRclCpp()`.

--- a/common_interfaces/build.zig
+++ b/common_interfaces/build.zig
@@ -1,0 +1,389 @@
+const std = @import("std");
+
+const RosidlGenerator = @import("../rosidl/src/RosidlGenerator.zig");
+
+const zigros = @import("../zigros/zigros.zig");
+
+const Dependency = std.Build.Dependency;
+const Run = std.Build.Step.Run;
+const Compile = std.Build.Step.Compile;
+const LazyPath = std.Build.LazyPath;
+const CompileArgs = zigros.CompileArgs;
+
+pub const Deps = struct {
+    upstream: *Dependency,
+    rosidl_generator: RosidlGenerator.Deps,
+    builtin_interfaces: RosidlGenerator.Interface,
+    service_msgs: RosidlGenerator.Interface,
+};
+
+pub const BuildDeps = struct {
+    rosidl_generator: RosidlGenerator.BuildDeps,
+};
+
+pub const Artifacts = struct {
+    actionlib_msgs: RosidlGenerator.Interface,
+    diagnostic_msgs: RosidlGenerator.Interface,
+    geometry_msgs: RosidlGenerator.Interface,
+    nav_msgs: RosidlGenerator.Interface,
+    std_msgs: RosidlGenerator.Interface,
+    std_srvs: RosidlGenerator.Interface,
+    sensor_msgs: RosidlGenerator.Interface,
+    shape_msgs: RosidlGenerator.Interface,
+    stereo_msgs: RosidlGenerator.Interface,
+    trajectory_msgs: RosidlGenerator.Interface,
+    visualization_msgs: RosidlGenerator.Interface,
+};
+
+pub fn buildWithArgs(b: *std.Build, args: CompileArgs, deps: Deps, build_deps: BuildDeps) Artifacts {
+    const upstream = deps.upstream;
+
+    // !! NOTE !!
+    // When adding interfaces, the "path" argument must be the root folder of that interface,
+    // meaning in this case "std_msgs", NOT the folder where the .msg files reside, e.g.
+    // "std_msgs/msg". This is required for proper generation of the interface types namespaced by
+    // 'msg', 'srv', etc. This means that each .msg file MUST be listed like "msg/Foo.msg" or
+    // "srv/Bar.srv", and NOT like "Foo.msg" or "Bar.srv".
+
+    ///////////////////////////////////////////////////////////////////////////
+    // std_msgs
+    ///////////////////////////////////////////////////////////////////////////
+    var std_msgs = RosidlGenerator.create(
+        b,
+        "std_msgs",
+        deps.rosidl_generator,
+        build_deps.rosidl_generator,
+        args,
+    );
+    std_msgs.addInterfaces(upstream.path("std_msgs"), &std_msgs_files);
+
+    // the example message uses the standard header message, so we must add builtin_interfaces
+    // as a dependency
+    std_msgs.addDependency("builtin_interfaces", deps.builtin_interfaces);
+    std_msgs.installArtifacts();
+
+    ///////////////////////////////////////////////////////////////////////////
+    // std_srvs
+    ///////////////////////////////////////////////////////////////////////////
+    var std_srvs = RosidlGenerator.create(
+        b,
+        "std_srvs",
+        deps.rosidl_generator,
+        build_deps.rosidl_generator,
+        args,
+    );
+    std_srvs.addInterfaces(upstream.path("std_srvs"), &std_srvs_files);
+    std_srvs.addDependency("builtin_interfaces", deps.builtin_interfaces);
+    std_srvs.addDependency("service_msgs", deps.service_msgs);
+    std_srvs.installArtifacts();
+
+    ///////////////////////////////////////////////////////////////////////////
+    // geometry_msgs
+    ///////////////////////////////////////////////////////////////////////////
+    var geometry_msgs = RosidlGenerator.create(
+        b,
+        "geometry_msgs",
+        deps.rosidl_generator,
+        build_deps.rosidl_generator,
+        args,
+    );
+    geometry_msgs.addInterfaces(upstream.path("geometry_msgs"), &geometry_msgs_files);
+    geometry_msgs.addDependency("builtin_interfaces", deps.builtin_interfaces);
+    geometry_msgs.addDependency("std_msgs", std_msgs.artifacts);
+    geometry_msgs.installArtifacts();
+
+    ///////////////////////////////////////////////////////////////////////////
+    // actionlib_msgs
+    ///////////////////////////////////////////////////////////////////////////
+    var actionlib_msgs = RosidlGenerator.create(
+        b,
+        "actionlib_msgs",
+        deps.rosidl_generator,
+        build_deps.rosidl_generator,
+        args,
+    );
+    actionlib_msgs.addInterfaces(upstream.path("actionlib_msgs"), &actionlib_msgs_files);
+    actionlib_msgs.addDependency("builtin_interfaces", deps.builtin_interfaces);
+    actionlib_msgs.addDependency("std_msgs", std_msgs.artifacts);
+    actionlib_msgs.installArtifacts();
+
+    ///////////////////////////////////////////////////////////////////////////
+    // diagnostic_msgs
+    ///////////////////////////////////////////////////////////////////////////
+    var diagnostic_msgs = RosidlGenerator.create(
+        b,
+        "diagnostic_msgs",
+        deps.rosidl_generator,
+        build_deps.rosidl_generator,
+        args,
+    );
+    diagnostic_msgs.addInterfaces(upstream.path("diagnostic_msgs"), &diagnostic_msgs_files);
+    diagnostic_msgs.addDependency("builtin_interfaces", deps.builtin_interfaces);
+    diagnostic_msgs.addDependency("std_msgs", std_msgs.artifacts);
+    diagnostic_msgs.addDependency("geometry_msgs", geometry_msgs.artifacts);
+    diagnostic_msgs.installArtifacts();
+
+    ///////////////////////////////////////////////////////////////////////////
+    // nav_msgs
+    ///////////////////////////////////////////////////////////////////////////
+    var nav_msgs = RosidlGenerator.create(
+        b,
+        "nav_msgs",
+        deps.rosidl_generator,
+        build_deps.rosidl_generator,
+        args,
+    );
+    nav_msgs.addInterfaces(upstream.path("nav_msgs"), &nav_msgs_files);
+    nav_msgs.addDependency("builtin_interfaces", deps.builtin_interfaces);
+    nav_msgs.addDependency("std_msgs", std_msgs.artifacts);
+    nav_msgs.addDependency("geometry_msgs", geometry_msgs.artifacts);
+    nav_msgs.installArtifacts();
+
+    ///////////////////////////////////////////////////////////////////////////
+    // sensor_msgs
+    ///////////////////////////////////////////////////////////////////////////
+    var sensor_msgs = RosidlGenerator.create(
+        b,
+        "sensor_msgs",
+        deps.rosidl_generator,
+        build_deps.rosidl_generator,
+        args,
+    );
+    sensor_msgs.addInterfaces(upstream.path("sensor_msgs"), &sensor_msgs_files);
+    sensor_msgs.addDependency("builtin_interfaces", deps.builtin_interfaces);
+    sensor_msgs.addDependency("std_msgs", std_msgs.artifacts);
+    sensor_msgs.addDependency("geometry_msgs", geometry_msgs.artifacts);
+    sensor_msgs.installArtifacts();
+
+    ///////////////////////////////////////////////////////////////////////////
+    // shape_msgs
+    ///////////////////////////////////////////////////////////////////////////
+    var shape_msgs = RosidlGenerator.create(
+        b,
+        "shape_msgs",
+        deps.rosidl_generator,
+        build_deps.rosidl_generator,
+        args,
+    );
+    shape_msgs.addInterfaces(upstream.path("shape_msgs"), &shape_msgs_files);
+    shape_msgs.addDependency("geometry_msgs", geometry_msgs.artifacts);
+    shape_msgs.installArtifacts();
+
+    ///////////////////////////////////////////////////////////////////////////
+    // stereo_msgs
+    ///////////////////////////////////////////////////////////////////////////
+    var stereo_msgs = RosidlGenerator.create(
+        b,
+        "stereo_msgs",
+        deps.rosidl_generator,
+        build_deps.rosidl_generator,
+        args,
+    );
+    stereo_msgs.addInterfaces(upstream.path("stereo_msgs"), &stereo_msgs_files);
+    stereo_msgs.addDependency("builtin_interfaces", deps.builtin_interfaces);
+    stereo_msgs.addDependency("std_msgs", std_msgs.artifacts);
+    stereo_msgs.addDependency("sensor_msgs", sensor_msgs.artifacts);
+    stereo_msgs.installArtifacts();
+
+    ///////////////////////////////////////////////////////////////////////////
+    // trajectory_msgs
+    ///////////////////////////////////////////////////////////////////////////
+    var trajectory_msgs = RosidlGenerator.create(
+        b,
+        "trajectory_msgs",
+        deps.rosidl_generator,
+        build_deps.rosidl_generator,
+        args,
+    );
+    trajectory_msgs.addInterfaces(upstream.path("trajectory_msgs"), &trajectory_msgs_files);
+    trajectory_msgs.addDependency("builtin_interfaces", deps.builtin_interfaces);
+    trajectory_msgs.addDependency("std_msgs", std_msgs.artifacts);
+    trajectory_msgs.addDependency("geometry_msgs", geometry_msgs.artifacts);
+    trajectory_msgs.installArtifacts();
+
+    ///////////////////////////////////////////////////////////////////////////
+    // visualization_msgs
+    ///////////////////////////////////////////////////////////////////////////
+    var visualization_msgs = RosidlGenerator.create(
+        b,
+        "visualization_msgs",
+        deps.rosidl_generator,
+        build_deps.rosidl_generator,
+        args,
+    );
+    visualization_msgs.addInterfaces(upstream.path("visualization_msgs"), &visualization_msgs_files);
+    visualization_msgs.addDependency("builtin_interfaces", deps.builtin_interfaces);
+    visualization_msgs.addDependency("std_msgs", std_msgs.artifacts);
+    visualization_msgs.addDependency("geometry_msgs", geometry_msgs.artifacts);
+    visualization_msgs.addDependency("sensor_msgs", sensor_msgs.artifacts);
+    visualization_msgs.installArtifacts();
+
+    return Artifacts{
+        .actionlib_msgs = actionlib_msgs.artifacts,
+        .diagnostic_msgs = diagnostic_msgs.artifacts,
+        .geometry_msgs = geometry_msgs.artifacts,
+        .nav_msgs = nav_msgs.artifacts,
+        .sensor_msgs = sensor_msgs.artifacts,
+        .shape_msgs = shape_msgs.artifacts,
+        .std_msgs = std_msgs.artifacts,
+        .std_srvs = std_srvs.artifacts,
+        .stereo_msgs = stereo_msgs.artifacts,
+        .trajectory_msgs = trajectory_msgs.artifacts,
+        .visualization_msgs = visualization_msgs.artifacts,
+    };
+}
+
+const actionlib_msgs_files = [_][]const u8{
+    "msg/GoalID.msg",
+    "msg/GoalStatusArray.msg",
+    "msg/GoalStatus.msg",
+};
+
+const diagnostic_msgs_files = [_][]const u8{
+    "msg/DiagnosticArray.msg",
+    "msg/DiagnosticStatus.msg",
+    "msg/KeyValue.msg",
+};
+
+const geometry_msgs_files = [_][]const u8{
+    "msg/Accel.msg",
+    "msg/AccelStamped.msg",
+    "msg/AccelWithCovariance.msg",
+    "msg/AccelWithCovarianceStamped.msg",
+    "msg/Inertia.msg",
+    "msg/InertiaStamped.msg",
+    "msg/Point32.msg",
+    "msg/Point.msg",
+    "msg/PointStamped.msg",
+    "msg/PolygonInstance.msg",
+    "msg/PolygonInstanceStamped.msg",
+    "msg/Polygon.msg",
+    "msg/PolygonStamped.msg",
+    "msg/Pose2D.msg",
+    "msg/PoseArray.msg",
+    "msg/Pose.msg",
+    "msg/PoseStamped.msg",
+    "msg/PoseWithCovariance.msg",
+    "msg/PoseWithCovarianceStamped.msg",
+    "msg/Quaternion.msg",
+    "msg/QuaternionStamped.msg",
+    "msg/Transform.msg",
+    "msg/TransformStamped.msg",
+    "msg/Twist.msg",
+    "msg/TwistStamped.msg",
+    "msg/TwistWithCovariance.msg",
+    "msg/TwistWithCovarianceStamped.msg",
+    "msg/Vector3.msg",
+    "msg/Vector3Stamped.msg",
+    "msg/VelocityStamped.msg",
+    "msg/Wrench.msg",
+    "msg/WrenchStamped.msg",
+};
+
+const nav_msgs_files = [_][]const u8{
+    "msg/GridCells.msg",
+    "msg/MapMetaData.msg",
+    "msg/OccupancyGrid.msg",
+    "msg/Odometry.msg",
+    "msg/Path.msg",
+};
+
+const sensor_msgs_files = [_][]const u8{
+    "msg/BatteryState.msg",
+    "msg/CameraInfo.msg",
+    "msg/ChannelFloat32.msg",
+    "msg/CompressedImage.msg",
+    "msg/FluidPressure.msg",
+    "msg/Illuminance.msg",
+    "msg/Image.msg",
+    "msg/Imu.msg",
+    "msg/JointState.msg",
+    "msg/JoyFeedbackArray.msg",
+    "msg/JoyFeedback.msg",
+    "msg/Joy.msg",
+    "msg/LaserEcho.msg",
+    "msg/LaserScan.msg",
+    "msg/MagneticField.msg",
+    "msg/MultiDOFJointState.msg",
+    "msg/MultiEchoLaserScan.msg",
+    "msg/NavSatFix.msg",
+    "msg/NavSatStatus.msg",
+    "msg/PointCloud2.msg",
+    "msg/PointCloud.msg",
+    "msg/PointField.msg",
+    "msg/Range.msg",
+    "msg/RegionOfInterest.msg",
+    "msg/RelativeHumidity.msg",
+    "msg/Temperature.msg",
+    "msg/TimeReference.msg",
+};
+
+const shape_msgs_files = [_][]const u8{
+    "msg/Mesh.msg",
+    "msg/MeshTriangle.msg",
+    "msg/Plane.msg",
+    "msg/SolidPrimitive.msg",
+};
+
+const std_msgs_files = [_][]const u8{
+    "msg/Bool.msg",
+    "msg/Byte.msg",
+    "msg/ByteMultiArray.msg",
+    "msg/Char.msg",
+    "msg/ColorRGBA.msg",
+    "msg/Empty.msg",
+    "msg/Float32.msg",
+    "msg/Float32MultiArray.msg",
+    "msg/Float64.msg",
+    "msg/Float64MultiArray.msg",
+    "msg/Header.msg",
+    "msg/Int16.msg",
+    "msg/Int16MultiArray.msg",
+    "msg/Int32.msg",
+    "msg/Int32MultiArray.msg",
+    "msg/Int64.msg",
+    "msg/Int64MultiArray.msg",
+    "msg/Int8.msg",
+    "msg/Int8MultiArray.msg",
+    "msg/MultiArrayDimension.msg",
+    "msg/MultiArrayLayout.msg",
+    "msg/String.msg",
+    "msg/UInt16.msg",
+    "msg/UInt16MultiArray.msg",
+    "msg/UInt32.msg",
+    "msg/UInt32MultiArray.msg",
+    "msg/UInt64.msg",
+    "msg/UInt64MultiArray.msg",
+    "msg/UInt8.msg",
+    "msg/UInt8MultiArray.msg",
+};
+
+const std_srvs_files = [_][]const u8{
+    "srv/Empty.srv",
+    "srv/SetBool.srv",
+    "srv/Trigger.srv",
+};
+
+const stereo_msgs_files = [_][]const u8{"msg/DisparityImage.msg"};
+
+const trajectory_msgs_files = [_][]const u8{
+    "msg/JointTrajectory.msg",
+    "msg/JointTrajectoryPoint.msg",
+    "msg/MultiDOFJointTrajectory.msg",
+    "msg/MultiDOFJointTrajectoryPoint.msg",
+};
+
+const visualization_msgs_files = [_][]const u8{
+    "msg/ImageMarker.msg",
+    "msg/InteractiveMarkerControl.msg",
+    "msg/InteractiveMarkerFeedback.msg",
+    "msg/InteractiveMarkerInit.msg",
+    "msg/InteractiveMarker.msg",
+    "msg/InteractiveMarkerPose.msg",
+    "msg/InteractiveMarkerUpdate.msg",
+    "msg/MarkerArray.msg",
+    "msg/Marker.msg",
+    "msg/MenuEntry.msg",
+    "msg/MeshFile.msg",
+    "msg/UVCoordinate.msg",
+};


### PR DESCRIPTION
Adds all interfaces from the [ROS2 common_interfaces repo](https://github.com/ros2/common_interfaces) to ZigROS's `rcl_libraries` field.

Sample usage (`build.zig`):

```zig
    const msg_compile_args: ZigRos.CompileArgs = .{ .target = target, .optimize = optimize, .linkage = linkage };

    // Normal setup for a custom interface with message and service types
    var example_msgs = zigros.createInterface(b, "example_msgs", msg_compile_args);

    // Depend on existing built-in message types
    example_msgs.addInterfaces(b.path("example_msgs"), &.{ "msg/Foo.msg", "msg/Bar.msg", "srv/Baz.srv" });
    example_msgs.addDependency("builtin_interfaces", zigros.ros_libraries.builtin_interfaces);
    example_msgs.addDependency("service_msgs", zigros.ros_libraries.service_msgs);

    // Depend on `std_msgs` and `geometry_msgs`
    example_msgs.addDependency("std_msgs", zigros.ros_libraries.std_msgs);
    example_msgs.addDependency("geometry_msgs", zigros.ros_libraries.geometry_msgs);

    example_msgs.installArtifacts();

    // ... more build.zig content ...

    // Link a custom module to the `example_msgs` interface, including all dependencies
    example_msgs.artifacts.linkCpp(my_example_module_1);

    // Link a custom module to `geometry_msgs` specifically
    zigros.ros_libraries.geometry_msgs.linkCpp(my_example_module_2);
    // However, this 2nd approach is not required, as `zigros.linkRclCpp()` or `zigros.linkRcl()` will take care of this for you.
```